### PR TITLE
Addition of an alert when trying to refine models when no models have been generated

### DIFF
--- a/vagabond/gui/AddEntity.cpp
+++ b/vagabond/gui/AddEntity.cpp
@@ -287,8 +287,8 @@ void AddEntity::loadConfSpaceView(std::string suffix)
 	{
 		if (_obj.modelCount()==0)
 		{
-			throw std::invalid_argument("No models detected, have you mode\
-			led your entities?");
+			throw std::invalid_argument("No models detected, have you modeled"\
+			" your entities?");
 		}
 
 		ConfSpaceView *view = new ConfSpaceView(this, &_obj);
@@ -364,20 +364,20 @@ void AddEntity::buttonPressed(std::string tag, Button *button)
 		{
 			if (_obj.modelCount()==0)
 			{
-				throw std::invalid_argument("No models detected, have you mode\
-				led your sequences?");
+				throw std::invalid_argument("No models detected, have you mode"\
+						"led your sequences?");
 			}
-			SerialRefiner *refiner = new SerialRefiner(this, &_obj);
-			refiner->setJobType(rope::ThoroughRefine);
-			refiner->show();
-			return;
 		}
-		catch(std::invalid_argument &err)
+		catch(std::exception &err)
 		{
 			BadChoice *brr = new BadChoice(this, err.what());
 			setModal(brr);
 			return;
-		}
+		} 
+		SerialRefiner *refiner = new SerialRefiner(this, &_obj);
+		refiner->setJobType(rope::ThoroughRefine);
+		refiner->show();
+		return;
 	}
 	else if (tag == "fix_issues")
 	{

--- a/vagabond/gui/AddEntity.cpp
+++ b/vagabond/gui/AddEntity.cpp
@@ -283,32 +283,31 @@ void AddEntity::searchPdb()
 
 void AddEntity::loadConfSpaceView(std::string suffix)
 {
-        try
-        {
-                if (_obj.modelCount()==0)
-                {
-                        throw std::invalid_argument("No models detected, have you modeled your entities?");
-                }
+	try
+	{
+		if (_obj.modelCount()==0)
+		{
+			throw std::invalid_argument("No models detected, have you modeled your entities?");
+		}
 
-                ConfSpaceView *view = new ConfSpaceView(this, &_obj);
-                if (suffix == "refined_torsions")
-                {
-                        view->setMode(rope::ConfTorsions);
-                }
-                else if (suffix == "atom_positions")
-                {
-                        view->setMode(rope::ConfPositional);
+		ConfSpaceView *view = new ConfSpaceView(this, &_obj);
+		if (suffix == "refined_torsions")
+		{
+			view->setMode(rope::ConfTorsions);
+		}
+		else if (suffix == "atom_positions")
+		{
+			view->setMode(rope::ConfPositional);
 		}
 		view->show();
                 
-        }
-        catch(std::exception &err)
-        {
-                
+	}
+	catch(std::exception &err)
+	{
 		BadChoice *brr = new BadChoice(this, err.what());
-                setModal(brr);
-                return;
-        }
+		setModal(brr);
+		return;
+	}
 }
 
 void AddEntity::buttonPressed(std::string tag, Button *button)
@@ -360,24 +359,23 @@ void AddEntity::buttonPressed(std::string tag, Button *button)
 	}
 	else if (tag == "refine")
 	{
-                try
-                {
-                        if (_obj.modelCount()==0)
-                        {
-                                throw std::invalid_argument("No models detected, have you modeled your sequences?");
-                        }
-                        SerialRefiner *refiner = new SerialRefiner(this, &_obj);
-                        refiner->setJobType(rope::ThoroughRefine);
-                        refiner->show();
-                        return;
-
-                }
-                catch(std::invalid_argument &err)
-                {
-                        BadChoice *brr = new BadChoice(this, err.what());
-                        setModal(brr);
-                        return;
-                }
+		try
+		{
+			if (_obj.modelCount()==0)
+			{
+				throw std::invalid_argument("No models detected, have you modeled your sequences?");
+			}
+			SerialRefiner *refiner = new SerialRefiner(this, &_obj);
+			refiner->setJobType(rope::ThoroughRefine);
+			refiner->show();
+			return;
+		}
+		catch(std::invalid_argument &err)
+		{
+			BadChoice *brr = new BadChoice(this, err.what());
+			setModal(brr);
+			return;
+		}
 	}
 	else if (tag == "fix_issues")
 	{

--- a/vagabond/gui/AddEntity.cpp
+++ b/vagabond/gui/AddEntity.cpp
@@ -34,6 +34,8 @@
 #include <vagabond/core/EntityManager.h>
 #include <vagabond/core/Sequence.h>
 #include <vagabond/core/Chain.h>
+#include <vagabond/core/Entity.h>
+
 
 #include <vagabond/gui/DistanceMaker.h>
 #include <vagabond/gui/DisplayOptions.h>
@@ -281,26 +283,38 @@ void AddEntity::searchPdb()
 
 void AddEntity::loadConfSpaceView(std::string suffix)
 {
-	ConfSpaceView *view = new ConfSpaceView(this, &_obj);
-	
-	if (suffix == "refined_torsions")
-	{
-		view->setMode(rope::ConfTorsions);
-	}
-	else if (suffix == "atom_positions")
-	{
-		view->setMode(rope::ConfPositional);
-	}
+        try
+        {
+                if (_obj.modelCount()==0)
+                {
+                        throw std::invalid_argument("No models detected, have you modeled your entities?");
+                }
 
-	try
-	{
-		view->show();
-	}
-	catch (const std::runtime_error &err)
-	{
-		BadChoice *bc = new BadChoice(this, err.what());
-		setModal(bc);
-	}
+                ConfSpaceView *view = new ConfSpaceView(this, &_obj);
+                if (suffix == "refined_torsions")
+                {
+                        view->setMode(rope::ConfTorsions);
+                }
+                else if (suffix == "atom_positions")
+                {
+                        view->setMode(rope::ConfPositional);
+                }
+                        try
+                {
+                        view->show();
+                }
+                catch (const std::runtime_error &err)
+                {
+                        BadChoice *bc = new BadChoice(this, err.what());
+                        setModal(bc);
+                }
+        }
+        catch(std::invalid_argument &err)
+        {
+                BadChoice *brr = new BadChoice(this, err.what());
+                setModal(brr);
+                return;
+        }
 }
 
 void AddEntity::buttonPressed(std::string tag, Button *button)
@@ -352,10 +366,24 @@ void AddEntity::buttonPressed(std::string tag, Button *button)
 	}
 	else if (tag == "refine")
 	{
-		SerialRefiner *refiner = new SerialRefiner(this, &_obj);
-		refiner->setJobType(rope::ThoroughRefine);
-		refiner->show();
-		return;
+                try
+                {
+                        if (_obj.modelCount()==0)
+                        {
+                                throw std::invalid_argument("No models detected, have you modeled your sequences?");
+                        }
+                        SerialRefiner *refiner = new SerialRefiner(this, &_obj);
+                        refiner->setJobType(rope::ThoroughRefine);
+                        refiner->show();
+                        return;
+
+                }
+                catch(std::invalid_argument &err)
+                {
+                        BadChoice *brr = new BadChoice(this, err.what());
+                        setModal(brr);
+                        return;
+                }
 	}
 	else if (tag == "fix_issues")
 	{

--- a/vagabond/gui/AddEntity.cpp
+++ b/vagabond/gui/AddEntity.cpp
@@ -298,20 +298,14 @@ void AddEntity::loadConfSpaceView(std::string suffix)
                 else if (suffix == "atom_positions")
                 {
                         view->setMode(rope::ConfPositional);
-                }
-                        try
-                {
-                        view->show();
-                }
-                catch (const std::runtime_error &err)
-                {
-                        BadChoice *bc = new BadChoice(this, err.what());
-                        setModal(bc);
-                }
+		}
+		view->show();
+                
         }
-        catch(std::invalid_argument &err)
+        catch(std::exception &err)
         {
-                BadChoice *brr = new BadChoice(this, err.what());
+                
+		BadChoice *brr = new BadChoice(this, err.what());
                 setModal(brr);
                 return;
         }

--- a/vagabond/gui/AddEntity.cpp
+++ b/vagabond/gui/AddEntity.cpp
@@ -287,7 +287,8 @@ void AddEntity::loadConfSpaceView(std::string suffix)
 	{
 		if (_obj.modelCount()==0)
 		{
-			throw std::invalid_argument("No models detected, have you modeled your entities?");
+			throw std::invalid_argument("No models detected, have you mode\
+			led your entities?");
 		}
 
 		ConfSpaceView *view = new ConfSpaceView(this, &_obj);
@@ -363,7 +364,8 @@ void AddEntity::buttonPressed(std::string tag, Button *button)
 		{
 			if (_obj.modelCount()==0)
 			{
-				throw std::invalid_argument("No models detected, have you modeled your sequences?");
+				throw std::invalid_argument("No models detected, have you mode\
+				led your sequences?");
 			}
 			SerialRefiner *refiner = new SerialRefiner(this, &_obj);
 			refiner->setJobType(rope::ThoroughRefine);

--- a/vagabond/gui/AddEntity.h
+++ b/vagabond/gui/AddEntity.h
@@ -44,6 +44,7 @@ public:
 	virtual void buttonPressed(std::string tag, Button *button = nullptr);
 private:
 	void loadConfSpaceView(std::string suffix);
+	void serialRefinement();
 	void textOrChoose(std::string &file, std::string other);
 	void refreshInfo();
 	void searchPdb();

--- a/vagabond/gui/elements/Window.cpp
+++ b/vagabond/gui/elements/Window.cpp
@@ -339,6 +339,7 @@ void Window::setCurrentScene(Scene *scene)
 	}
 	_current = scene;
 	_current->setDims(_rect.w, _rect.h);
+	_switchMutex.unlock();
 	_current->preSetup();
 }
 


### PR DESCRIPTION
When entering Refine and Rope Space, an alert is showing and avoids getting soft-locked in the Refinement windows